### PR TITLE
cmd: Silence usage when handled error returns.

### DIFF
--- a/cmd/qsctl/cat.go
+++ b/cmd/qsctl/cat.go
@@ -21,7 +21,8 @@ var CatCommand = &cobra.Command{
 	RunE: catRun,
 }
 
-func catRun(_ *cobra.Command, args []string) (err error) {
+func catRun(c *cobra.Command, args []string) (err error) {
+	silenceUsage(c) // silence usage when handled error returns
 	rootTask := taskutils.NewBetweenStorageTask(10)
 	_, _, err = utils.ParseBetweenStorageInput(rootTask, args[0], "-")
 	if err != nil {

--- a/cmd/qsctl/cp.go
+++ b/cmd/qsctl/cp.go
@@ -58,7 +58,8 @@ accept: 100MB, 1.8G
 	)
 }
 
-func cpRun(_ *cobra.Command, args []string) (err error) {
+func cpRun(c *cobra.Command, args []string) (err error) {
+	silenceUsage(c) // silence usage when handled error returns
 	rootTask := taskutils.NewBetweenStorageTask(10)
 	srcWorkDir, dstWorkDir, err := utils.ParseBetweenStorageInput(rootTask, args[0], args[1])
 	if err != nil {

--- a/cmd/qsctl/init.go
+++ b/cmd/qsctl/init.go
@@ -141,3 +141,7 @@ func initGlobalFlag() {
 	rootCmd.PersistentFlags().Bool("help", false, i18n.Sprintf("help for this command"))
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, i18n.Sprintf("print logs for debug"))
 }
+
+func silenceUsage(c *cobra.Command) {
+	c.SilenceUsage = true
+}

--- a/cmd/qsctl/ls.go
+++ b/cmd/qsctl/ls.go
@@ -39,7 +39,8 @@ var LsCommand = &cobra.Command{
 	RunE: lsRun,
 }
 
-func lsRun(_ *cobra.Command, args []string) (err error) {
+func lsRun(c *cobra.Command, args []string) (err error) {
+	silenceUsage(c) // silence usage when handled error returns
 	if len(args) == 0 {
 		rootTask := taskutils.NewAtServiceTask(10)
 		err = utils.ParseAtServiceInput(rootTask)

--- a/cmd/qsctl/mb.go
+++ b/cmd/qsctl/mb.go
@@ -36,7 +36,8 @@ bucket name should follow DNS name rule with:
 	PreRunE: validateMbFlag,
 }
 
-func mbRun(_ *cobra.Command, args []string) (err error) {
+func mbRun(c *cobra.Command, args []string) (err error) {
+	silenceUsage(c) // silence usage when handled error returns
 	rootTask := taskutils.NewAtServiceTask(10)
 	err = utils.ParseAtServiceInput(rootTask)
 	if err != nil {

--- a/cmd/qsctl/mv.go
+++ b/cmd/qsctl/mv.go
@@ -40,7 +40,8 @@ func initMvFlag() {
 		i18n.Sprintf("move directory recursively"))
 }
 
-func mvRun(_ *cobra.Command, args []string) (err error) {
+func mvRun(c *cobra.Command, args []string) (err error) {
+	silenceUsage(c) // silence usage when handled error returns
 	rootTask := taskutils.NewBetweenStorageTask(10)
 	srcWorkDir, dstWorkDir, err := utils.ParseBetweenStorageInput(rootTask, args[0], args[1])
 	if err != nil {

--- a/cmd/qsctl/presign.go
+++ b/cmd/qsctl/presign.go
@@ -34,7 +34,8 @@ this URL can always retrieve the object with an HTTP GET request.`),
 	PreRun: validatePresignFlag,
 }
 
-func presignRun(_ *cobra.Command, args []string) (err error) {
+func presignRun(c *cobra.Command, args []string) (err error) {
+	silenceUsage(c) // silence usage when handled error returns
 	rootTask := taskutils.NewAtStorageTask(10)
 	_, err = utils.ParseAtStorageInput(rootTask, args[0])
 	if err != nil {

--- a/cmd/qsctl/rb.go
+++ b/cmd/qsctl/rb.go
@@ -33,7 +33,8 @@ func initRbFlag() {
 	)
 }
 
-func rbRun(_ *cobra.Command, args []string) (err error) {
+func rbRun(c *cobra.Command, args []string) (err error) {
+	silenceUsage(c) // silence usage when handled error returns
 	rootTask := taskutils.NewAtServiceTask(10)
 	err = utils.ParseAtServiceInput(rootTask)
 	if err != nil {

--- a/cmd/qsctl/rm.go
+++ b/cmd/qsctl/rm.go
@@ -35,7 +35,8 @@ func initRmFlag() {
 		false, i18n.Sprintf("recursively delete keys under a specific prefix"))
 }
 
-func rmRun(_ *cobra.Command, args []string) (err error) {
+func rmRun(c *cobra.Command, args []string) (err error) {
+	silenceUsage(c) // silence usage when handled error returns
 	rootTask := taskutils.NewAtStorageTask(10)
 	workDir, err := utils.ParseAtStorageInput(rootTask, args[0])
 	if err != nil {

--- a/cmd/qsctl/stat.go
+++ b/cmd/qsctl/stat.go
@@ -32,7 +32,8 @@ var StatCommand = &cobra.Command{
 	RunE: statRun,
 }
 
-func statRun(_ *cobra.Command, args []string) (err error) {
+func statRun(c *cobra.Command, args []string) (err error) {
+	silenceUsage(c) // silence usage when handled error returns
 	rootTask := taskutils.NewAtStorageTask(10)
 	_, err = utils.ParseAtStorageInput(rootTask, args[0])
 	if err != nil {

--- a/cmd/qsctl/sync.go
+++ b/cmd/qsctl/sync.go
@@ -37,7 +37,8 @@ key(file) will be overwritten only if the source one newer than destination one.
 	RunE: syncRun,
 }
 
-func syncRun(_ *cobra.Command, args []string) (err error) {
+func syncRun(c *cobra.Command, args []string) (err error) {
+	silenceUsage(c) // silence usage when handled error returns
 	rootTask := taskutils.NewBetweenStorageTask(10)
 	srcWorkDir, dstWorkDir, err := utils.ParseBetweenStorageInput(rootTask, args[0], args[1])
 	if err != nil {

--- a/cmd/qsctl/tee.go
+++ b/cmd/qsctl/tee.go
@@ -34,7 +34,8 @@ NOTICE: qsctl will not tee the content to stdout like linux tee command does.
 	PreRunE: validateTeeFlag,
 }
 
-func teeRun(_ *cobra.Command, args []string) (err error) {
+func teeRun(c *cobra.Command, args []string) (err error) {
+	silenceUsage(c) // silence usage when handled error returns
 	rootTask := taskutils.NewBetweenStorageTask(10)
 	_, dstWorkDir, err := utils.ParseBetweenStorageInput(rootTask, "-", args[0])
 	if err != nil {


### PR DESCRIPTION
All flags check and parse was implements in `PreRun`, so we need to silence command usage after it and right before `Run`.