### PR TITLE
cmd/qsctl: Remove progress bar for better performance

### DIFF
--- a/cmd/qsctl/cp.go
+++ b/cmd/qsctl/cp.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"path/filepath"
-	"time"
 
 	"github.com/Xuanwo/storage/types"
 	"github.com/qingstor/noah/task"
@@ -80,11 +79,6 @@ func cpRun(c *cobra.Command, args []string) (err error) {
 		return fmt.Errorf(i18n.Sprintf("cannot copy a directory to a non-directory dest"))
 	}
 
-	go func() {
-		taskutils.StartProgress(time.Second, 3)
-	}()
-	defer taskutils.FinishProgress()
-
 	if cpInput.Recursive {
 		t := task.NewCopyDir(rootTask)
 		t.SetCheckTasks(nil)
@@ -94,7 +88,6 @@ func cpRun(c *cobra.Command, args []string) (err error) {
 			return t.GetFault()
 		}
 
-		taskutils.WaitProgress()
 		i18n.Printf("Dir <%s> copied to <%s>.\n",
 			filepath.Join(srcWorkDir, t.GetSourcePath()), filepath.Join(dstWorkDir, t.GetDestinationPath()))
 		return nil
@@ -107,7 +100,6 @@ func cpRun(c *cobra.Command, args []string) (err error) {
 		return t.GetFault()
 	}
 
-	taskutils.WaitProgress()
 	i18n.Printf("File <%s> copied to <%s>.\n",
 		filepath.Join(srcWorkDir, t.GetSourcePath()), filepath.Join(dstWorkDir, t.GetDestinationPath()))
 	return

--- a/cmd/qsctl/mv.go
+++ b/cmd/qsctl/mv.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"path/filepath"
-	"time"
 
 	"github.com/Xuanwo/storage/types"
 	"github.com/qingstor/noah/task"
@@ -62,11 +61,6 @@ func mvRun(c *cobra.Command, args []string) (err error) {
 		return fmt.Errorf(i18n.Sprintf("cannot move a directory to a non-directory dest"))
 	}
 
-	go func() {
-		taskutils.StartProgress(time.Second, 3)
-	}()
-	defer taskutils.FinishProgress()
-
 	if mvInput.Recursive {
 		t := task.NewMoveDir(rootTask)
 		t.Run()
@@ -74,7 +68,6 @@ func mvRun(c *cobra.Command, args []string) (err error) {
 		if t.GetFault().HasError() {
 			return t.GetFault()
 		}
-		taskutils.WaitProgress()
 		i18n.Printf("Dir <%s> moved to <%s>.\n",
 			filepath.Join(srcWorkDir, t.GetSourcePath()), filepath.Join(dstWorkDir, t.GetDestinationPath()))
 		return nil
@@ -85,7 +78,6 @@ func mvRun(c *cobra.Command, args []string) (err error) {
 	if t.GetFault().HasError() {
 		return t.GetFault()
 	}
-	taskutils.WaitProgress()
 	i18n.Printf("File <%s> moved to <%s>.\n",
 		filepath.Join(srcWorkDir, t.GetSourcePath()), filepath.Join(dstWorkDir, t.GetDestinationPath()))
 	return

--- a/cmd/qsctl/sync.go
+++ b/cmd/qsctl/sync.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"path/filepath"
-	"time"
 
 	"github.com/Xuanwo/storage/types"
 	"github.com/qingstor/noah/task"
@@ -57,11 +56,6 @@ func syncRun(c *cobra.Command, args []string) (err error) {
 		return fmt.Errorf("both --existing and --ignore-existing are set, no files would be synced")
 	}
 
-	go func() {
-		taskutils.StartProgress(time.Second, 3)
-	}()
-	defer taskutils.FinishProgress()
-
 	t := task.NewSync(rootTask)
 	t.SetDryRun(syncInput.DryRun)
 	t.SetExisting(syncInput.Existing)
@@ -81,7 +75,6 @@ func syncRun(c *cobra.Command, args []string) (err error) {
 	if t.GetFault().HasError() {
 		return t.GetFault()
 	}
-	taskutils.WaitProgress()
 	i18n.Printf("Dir <%s> and <%s> synced.\n",
 		filepath.Join(srcWorkDir, t.GetSourcePath()), filepath.Join(dstWorkDir, t.GetDestinationPath()))
 	return nil

--- a/cmd/qsctl/tee.go
+++ b/cmd/qsctl/tee.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"path/filepath"
-	"time"
 
 	"github.com/qingstor/noah/task"
 	"github.com/spf13/cobra"
@@ -42,18 +41,12 @@ func teeRun(c *cobra.Command, args []string) (err error) {
 		return
 	}
 
-	go func() {
-		taskutils.StartProgress(time.Second, 3)
-	}()
-	defer taskutils.FinishProgress()
-
 	t := task.NewCopyStream(rootTask)
 	t.SetPartSize(constants.DefaultPartSize)
 	t.Run()
 	if t.GetFault().HasError() {
 		return t.GetFault()
 	}
-	taskutils.WaitProgress()
 	i18n.Printf("Stdin copied to <%s>.\n", filepath.Join(dstWorkDir, t.GetDestinationPath()))
 	return nil
 }


### PR DESCRIPTION
For now, progress bar seems that could not satisfy for performance in qsctl. So we temporarily remove it, and re-add it as soon as possible. 