### PR TITLE
cmd/progress-bar: Fix data race in progress bar

### DIFF
--- a/cmd/qsctl/taskutils/progress.go
+++ b/cmd/qsctl/taskutils/progress.go
@@ -93,6 +93,7 @@ func init() {
 // The data from noah is a map with taskID as key and its state as value.
 // So we range the data and update relevant bar's progress.
 func StartProgress(d time.Duration) {
+	wg.Add(1)
 	tc := time.NewTicker(d)
 	for {
 		select {
@@ -138,13 +139,14 @@ func StartProgress(d time.Duration) {
 
 // WaitProgress wait the progress bar to complete
 func WaitProgress() {
+	wg.Done()
 	pbPool.Wait()
 }
 
 // FinishProgress finish the progress bar and close the progress center
 func FinishProgress() {
-	close(sigChan)
 	cancel()
+	close(sigChan)
 }
 
 // GetPBarByID returns the pbar's pointer with given taskID


### PR DESCRIPTION
When task done more quickly than progress bar render, the `wg` would cause data race.
Because the `WaitProgress` would call `wait()` as write before `wg.Add()` as read.
So we `add` the `wg` at the start of `StartProgress`, and `done` while call `WaitProgress` for balance.
See more details in #283 