### PR TITLE
ci: Update go to recent two versions

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        go: [ "1.14", "1.15" ]
+        go: [ "1.16", "1.17" ]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:

--- a/cmd/qsctl/shell.go
+++ b/cmd/qsctl/shell.go
@@ -277,7 +277,7 @@ func noSuggests(_ prompt.Document) []prompt.Suggest {
 
 // monitorSignal check specific to call cancelFunc of passing context
 func monitorSignal(ctx context.Context, cancelFunc context.CancelFunc, sigs ...os.Signal) {
-	sigChan := make(chan os.Signal)
+	sigChan := make(chan os.Signal, 1)
 	signal.Notify(sigChan, sigs...)
 	select {
 	case <-sigChan:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/qingstor/qsctl/v2
 
-go 1.14
+go 1.16
 
 require (
 	bou.ke/monkey v1.0.2

--- a/utils/task_unix_test.go
+++ b/utils/task_unix_test.go
@@ -1,3 +1,4 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
 // +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package utils

--- a/utils/work_dir_unix_test.go
+++ b/utils/work_dir_unix_test.go
@@ -1,3 +1,4 @@
+//go:build aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
 // +build aix darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package utils


### PR DESCRIPTION
Rational:
go.sum written by go1.17 no longer compatible with go < 1.16, which leads to ci test failure.
We should always use the latest two minor versions of go in ci.

Some go-vet warnings become error after go update, fix those go-vet warnings.