### PR TITLE
feat: Allow object keys include multiple slashes if configured

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,6 +1,8 @@
 name: "Unit Test"
 
-on: [push,pull_request]
+on:
+  push:
+  pull_request:
 
 jobs:
   unit_test:
@@ -8,21 +10,22 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      fail-fast: false
       matrix:
         go: [ "1.16", "1.17" ]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ "ubuntu-latest", "windows-latest", "macos-latest" ]
 
     steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
 
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
       - name: Install mockgen
-        run: go get github.com/golang/mock/mockgen
+        run: go install github.com/golang/mock/mockgen@latest
 
       - name: Build
         run: make build

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ clean:
 
 test:
 	@echo "run test"
-	@go test -gcflags=-l -race -coverprofile=coverage.txt -covermode=atomic -v ./...
+	@go test -gcflags=all=-l -race -coverprofile=coverage.txt -covermode=atomic -v ./...
 	@go tool cover -html="coverage.txt" -o "coverage.html"
 	@echo "ok"
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,15 @@ CMD_PKG := github.com/qingstor/qsctl/v2/cmd/qsctl
 VERSION := $(shell cat ./constants/version.go | grep "Version\ =" | sed -e s/^.*\ //g | sed -e s/\"//g)
 GO_BUILD_OPTION := -trimpath -tags netgo
 
+OS := $(shell go env GOOS)
+
+RACE_FLAG :=
+ifeq ($(OS),windows)
+    RACE_FLAG :=
+else
+    RACE_FLAG := -race
+endif
+
 .PHONY: all check format vet build install uninstall release clean test generate build-linux package
 
 # nfpm: go get -u github.com/goreleaser/nfpm/cmd/nfpm
@@ -42,7 +51,7 @@ generate:
 build: tidy generate check
 	@echo "build qsctl"
 	@mkdir -p ./bin
-	@go build ${GO_BUILD_OPTION} -race -o ./bin/qsctl ${CMD_PKG}
+	@go build ${GO_BUILD_OPTION} $(RACE_FLAG) -o ./bin/qsctl ${CMD_PKG}
 	@echo "ok"
 
 build-linux: tidy generate check
@@ -94,7 +103,7 @@ clean:
 
 test:
 	@echo "run test"
-	@go test -gcflags=all=-l -race -coverprofile=coverage.txt -covermode=atomic -v ./...
+	@go test -gcflags=all=-l $(RACE_FLAG) -coverprofile=coverage.txt -covermode=atomic -v ./...
 	@go tool cover -html="coverage.txt" -o "coverage.html"
 	@echo "ok"
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ port: 443
 protocol: 'https'
 connection_retries: 3
 zone: 'zone_name'
+
+# By default, extra slashes in object key will be stripped from the path,
+# like `/a//b` become `a/b`, this option disable that behavior.
+# disable_uri_cleaning: true
 ```
 
 ~~You can also run qsctl command without config file, it will try to

--- a/cmd/qsctl/cat_test.go
+++ b/cmd/qsctl/cat_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"bou.ke/monkey"
+	"github.com/agiledragon/gomonkey/v2"
 	"github.com/google/uuid"
 	"github.com/qingstor/noah/pkg/fault"
 	"github.com/qingstor/noah/pkg/types"
@@ -45,7 +45,8 @@ func TestCatRun(t *testing.T) {
 	}
 
 	for _, tt := range cases {
-		monkey.Patch(utils.ParseBetweenStorageInput, func(_ interface {
+		patches := gomonkey.NewPatches()
+		patches.ApplyFunc(utils.ParseBetweenStorageInput, func(_ interface {
 			types.SourcePathSetter
 			types.SourceStorageSetter
 			types.SourceTypeSetter
@@ -61,7 +62,7 @@ func TestCatRun(t *testing.T) {
 			return
 		})
 		var tk *task.CopyFileTask
-		monkey.PatchInstanceMethod(reflect.TypeOf(tk), "Run", func(task *task.CopyFileTask, ctx context.Context) {
+		patches.ApplyMethod(reflect.TypeOf(tk), "Run", func(task *task.CopyFileTask, ctx context.Context) {
 			if tt.runErr != nil {
 				task.TriggerFault(tmpErr)
 			} else {
@@ -74,6 +75,6 @@ func TestCatRun(t *testing.T) {
 		} else {
 			assert.True(t, errors.Is(gotErr, tt.runErr), tt.name)
 		}
-		monkey.UnpatchAll()
+		patches.Reset()
 	}
 }

--- a/cmd/qsctl/cp.go
+++ b/cmd/qsctl/cp.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/aos-dev/go-storage/v2/types"
 	"github.com/qingstor/noah/task"
@@ -129,7 +128,7 @@ func cpRun(c *cobra.Command, args []string) (err error) {
 		}
 
 		i18n.Fprintf(c.OutOrStdout(), "Dir <%s> copied to <%s>.\n",
-			filepath.Join(srcWorkDir, t.GetSourcePath()), filepath.Join(dstWorkDir, t.GetDestinationPath()))
+			srcWorkDir+t.GetSourcePath(), dstWorkDir+t.GetDestinationPath())
 		return nil
 	}
 
@@ -151,7 +150,7 @@ func cpRun(c *cobra.Command, args []string) (err error) {
 	}
 
 	i18n.Fprintf(c.OutOrStdout(), "File <%s> copied to <%s>.\n",
-		filepath.Join(srcWorkDir, t.GetSourcePath()), filepath.Join(dstWorkDir, t.GetDestinationPath()))
+		srcWorkDir+t.GetSourcePath(), dstWorkDir+t.GetDestinationPath())
 	return
 }
 

--- a/cmd/qsctl/mv.go
+++ b/cmd/qsctl/mv.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/aos-dev/go-storage/v2/types"
 	"github.com/qingstor/noah/task"
@@ -110,7 +109,7 @@ func mvRun(c *cobra.Command, args []string) (err error) {
 		}
 
 		i18n.Fprintf(c.OutOrStdout(), "Dir <%s> moved to <%s>.\n",
-			filepath.Join(srcWorkDir, t.GetSourcePath()), filepath.Join(dstWorkDir, t.GetDestinationPath()))
+			srcWorkDir+t.GetSourcePath(), dstWorkDir+t.GetDestinationPath())
 		return nil
 	}
 
@@ -132,7 +131,7 @@ func mvRun(c *cobra.Command, args []string) (err error) {
 	}
 
 	i18n.Fprintf(c.OutOrStdout(), "File <%s> moved to <%s>.\n",
-		filepath.Join(srcWorkDir, t.GetSourcePath()), filepath.Join(dstWorkDir, t.GetDestinationPath()))
+		srcWorkDir+t.GetSourcePath(), dstWorkDir+t.GetDestinationPath())
 	return
 }
 

--- a/cmd/qsctl/rm.go
+++ b/cmd/qsctl/rm.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"path/filepath"
 
 	typ "github.com/aos-dev/go-storage/v2/types"
 	"github.com/c-bata/go-prompt"
@@ -63,7 +62,7 @@ func rmRun(c *cobra.Command, args []string) (err error) {
 		return fmt.Errorf(i18n.Sprintf("path should be a directory while -r is set"))
 	}
 
-	key := filepath.Join(workDir, rootTask.GetPath())
+	key := workDir + rootTask.GetPath()
 	if rmFlag.recursive {
 		t := task.NewDeleteDir(rootTask)
 		t.SetHandleObjCallback(func(o *typ.Object) {

--- a/cmd/qsctl/sync.go
+++ b/cmd/qsctl/sync.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"path/filepath"
 
 	"github.com/Xuanwo/navvy"
 	"github.com/aos-dev/go-storage/v2/types"
@@ -126,7 +125,7 @@ func syncRun(c *cobra.Command, args []string) (err error) {
 	}
 
 	i18n.Fprintf(c.OutOrStdout(), "Dir <%s> and <%s> synced.\n",
-		filepath.Join(srcWorkDir, t.GetSourcePath()), filepath.Join(dstWorkDir, t.GetDestinationPath()))
+		srcWorkDir+t.GetSourcePath(), dstWorkDir+t.GetDestinationPath())
 	return nil
 
 }

--- a/cmd/qsctl/tee.go
+++ b/cmd/qsctl/tee.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"path/filepath"
-
 	"github.com/qingstor/noah/task"
 	"github.com/spf13/cobra"
 
@@ -67,7 +65,7 @@ func teeRun(c *cobra.Command, args []string) (err error) {
 	if t.GetFault().HasError() {
 		return t.GetFault()
 	}
-	i18n.Fprintf(c.OutOrStdout(), "Stdin copied to <%s>.\n", filepath.Join(dstWorkDir, t.GetDestinationPath()))
+	i18n.Fprintf(c.OutOrStdout(), "Stdin copied to <%s>.\n", dstWorkDir+t.GetDestinationPath())
 	return nil
 }
 

--- a/constants/config.go
+++ b/constants/config.go
@@ -8,6 +8,7 @@ const (
 	ConfigProtocol           = "protocol"
 	ConfigLogLevel           = "log_level"
 	ConfigEnableVirtualStyle = "enable_virtual_style"
+	ConfigDisableURICleaning = "disable_uri_cleaning"
 
 	// Required config.
 	ConfigAccessKeyID     = "access_key_id"

--- a/docs/README-zh_CN.md
+++ b/docs/README-zh_CN.md
@@ -37,6 +37,10 @@ port: 443
 protocol: 'https'
 connection_retries: 3
 zone: 'zone_name'
+
+# 默认情况下，对象键中的多余斜杠会被从路径中移除，
+# 例如 `/a//b` 会变成 `a/b`，这个选项用于禁用该行为。
+# disable_uri_cleaning: true
 ```
 
 ~~您也可以在没有配置文件的情况下执行 qsctl 指令，它首先会自动在特定的目录下寻找配置文件，

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Xuanwo/go-locale v0.3.0
 	github.com/Xuanwo/navvy v0.0.0-20200811093125-d2896821f0d2
 	github.com/aos-dev/go-service-fs v0.0.0-20200701083751-3d91f2781716
-	github.com/aos-dev/go-service-qingstor v0.0.0-20230821085726-fd91c121fbaf
+	github.com/aos-dev/go-service-qingstor v0.0.0
 	github.com/aos-dev/go-storage/v2 v2.0.0-20200701095044-534f1fbfb062
 	github.com/c-bata/go-prompt v0.2.5
 	github.com/c2h5oh/datasize v0.0.0-20171227191756-4eba002a5eae
@@ -30,3 +30,5 @@ require (
 )
 
 replace github.com/spf13/cobra v1.0.0 => github.com/Prnyself/cobra v1.0.1-0.20200814081545-b584b1cb84aa
+
+replace github.com/aos-dev/go-service-qingstor v0.0.0 => github.com/qingstor/go-service-qingstor v0.0.0-20250425022544-d0c517cf42e7

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,10 @@ module github.com/qingstor/qsctl/v2
 go 1.16
 
 require (
-	bou.ke/monkey v1.0.2
 	github.com/AlecAivazis/survey/v2 v2.2.7
 	github.com/Xuanwo/go-locale v0.3.0
 	github.com/Xuanwo/navvy v0.0.0-20200811093125-d2896821f0d2
+	github.com/agiledragon/gomonkey/v2 v2.13.0
 	github.com/aos-dev/go-service-fs v0.0.0-20200701083751-3d91f2781716
 	github.com/aos-dev/go-service-qingstor v0.0.0
 	github.com/aos-dev/go-storage/v2 v2.0.0-20200701095044-534f1fbfb062

--- a/go.sum
+++ b/go.sum
@@ -65,6 +65,8 @@ github.com/Xuanwo/navvy v0.0.0-20200811093125-d2896821f0d2 h1:oGya5YgvunubJ+JFAQ
 github.com/Xuanwo/navvy v0.0.0-20200811093125-d2896821f0d2/go.mod h1:FfMsXg0w9OrzdLvhDHGzdBx35cw1qTpKLcGNC8RtgQA=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
+github.com/agiledragon/gomonkey/v2 v2.13.0 h1:B24Jg6wBI1iB8EFR1c+/aoTg7QN/Cum7YffG8KMIyYo=
+github.com/agiledragon/gomonkey/v2 v2.13.0/go.mod h1:ap1AmDzcVOAz1YpeJ3TCzIgstoaWLA6jbbgxfB4w2iY=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/aliyun/aliyun-oss-go-sdk v2.1.2+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=

--- a/go.sum
+++ b/go.sum
@@ -70,8 +70,6 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/aliyun/aliyun-oss-go-sdk v2.1.2+incompatible/go.mod h1:T/Aws4fEfogEE9v+HPhhw+CntffsBHJ8nXQCwKr0/g8=
 github.com/aos-dev/go-service-fs v0.0.0-20200701083751-3d91f2781716 h1:NLu9mpk9sbX5mjQnX4E1v2EI+Mxr6a4D2kZDFVH7hIE=
 github.com/aos-dev/go-service-fs v0.0.0-20200701083751-3d91f2781716/go.mod h1:3p4qSYKmS4CPu+n0E8bsT43j6nLdIorMaG4nGwgjrtk=
-github.com/aos-dev/go-service-qingstor v0.0.0-20230821085726-fd91c121fbaf h1:vqMLRHKBc6Nxeh5GzNgeqCXNZoIkGGMt9gJqSHoQJec=
-github.com/aos-dev/go-service-qingstor v0.0.0-20230821085726-fd91c121fbaf/go.mod h1:nkDeDqFc46xRs4Jo4hpY1COEe9Kyt/1kxN8GLHepGlc=
 github.com/aos-dev/go-storage/v2 v2.0.0-20200701075520-2a704cc6e299/go.mod h1:TVLcBruQEYqmOzj9zaIVfW3sg0vEiD5an6CoMXhQkoI=
 github.com/aos-dev/go-storage/v2 v2.0.0-20200701095044-534f1fbfb062 h1:GerKn/8KCo9CkUpJUjEYJGQFsQcAavqDoZBn3pLx+WE=
 github.com/aos-dev/go-storage/v2 v2.0.0-20200701095044-534f1fbfb062/go.mod h1:fdonF870IKNAqZMHnHr3gs/RImEqx9kjyJ33k4LtBEI=
@@ -304,6 +302,8 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/qingstor/go-mime v0.1.0 h1:FhTJtM7TRm9pfgCXpjGUxqwbumGojrgE9ecRz5PXvfc=
 github.com/qingstor/go-mime v0.1.0/go.mod h1:EDwWgaMufg74m7futsF0ZGkdA52ajjAycY+XDeV8M88=
+github.com/qingstor/go-service-qingstor v0.0.0-20250425022544-d0c517cf42e7 h1:qJibzWt/4rQ8TrFI5AwtGla+djd/ED3oM5r8yUskvAs=
+github.com/qingstor/go-service-qingstor v0.0.0-20250425022544-d0c517cf42e7/go.mod h1:nkDeDqFc46xRs4Jo4hpY1COEe9Kyt/1kxN8GLHepGlc=
 github.com/qingstor/log v0.0.0-20200804082313-615256cccabc h1:633tgwvkk8O26HZD/upVtDzWcrMoCiffZAVDtEtFW9E=
 github.com/qingstor/log v0.0.0-20200804082313-615256cccabc/go.mod h1:XfNhERXtkg/S9MWaMOk/m7mrmj4vcWDvhw17hmH4JGQ=
 github.com/qingstor/noah v0.0.0-20230706073119-d2404f9336d0 h1:I/G7Y06UWpZCDHXlMsnyglo2GRKIe5gYA06SEfYRAE4=

--- a/utils/check_test.go
+++ b/utils/check_test.go
@@ -4,8 +4,8 @@ import (
 	"regexp"
 	"testing"
 
-	"bou.ke/monkey"
 	"github.com/AlecAivazis/survey/v2"
+	"github.com/agiledragon/gomonkey/v2"
 )
 
 func TestSurvey_DoubleCheckString(t *testing.T) {
@@ -53,8 +53,9 @@ func TestSurvey_DoubleCheckString(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defer monkey.UnpatchAll()
-			monkey.Patch(survey.AskOne, func(p survey.Prompt, response interface{}, opts ...survey.AskOpt) error {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+			patches.ApplyFunc(survey.AskOne, func(p survey.Prompt, response interface{}, opts ...survey.AskOpt) error {
 				if tt.wantErr {
 					return errTmp
 				}
@@ -133,8 +134,9 @@ func TestConfirmCheck_CheckConfirm(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defer monkey.UnpatchAll()
-			monkey.Patch(survey.AskOne, func(p survey.Prompt, response interface{}, opts ...survey.AskOpt) error {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+			patches.ApplyFunc(survey.AskOne, func(p survey.Prompt, response interface{}, opts ...survey.AskOpt) error {
 				if tt.wantErr {
 					return errTmp
 				}

--- a/utils/task.go
+++ b/utils/task.go
@@ -6,8 +6,8 @@ import (
 	"os"
 	"strings"
 
-	"github.com/aos-dev/go-service-fs"
-	"github.com/aos-dev/go-service-qingstor"
+	fs "github.com/aos-dev/go-service-fs"
+	qingstor "github.com/aos-dev/go-service-qingstor"
 	"github.com/aos-dev/go-storage/v2"
 	"github.com/aos-dev/go-storage/v2/pkg/credential"
 	"github.com/aos-dev/go-storage/v2/pkg/endpoint"
@@ -288,6 +288,7 @@ func getQsServicePairs() []*typ.Pair {
 	)))
 
 	ps = append(ps, qingstor.WithEnableVirtualStyle(viper.GetBool(constants.ConfigEnableVirtualStyle)))
+	ps = append(ps, qingstor.WithDisableURICleaning(viper.GetBool(constants.ConfigDisableURICleaning)))
 
 	if zone := viper.GetString(constants.ConfigZone); zone != "" {
 		ps = append(ps, pairs.WithLocation(zone))

--- a/utils/task_test.go
+++ b/utils/task_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"bou.ke/monkey"
-	"github.com/aos-dev/go-service-fs"
-	"github.com/aos-dev/go-service-qingstor"
+	fs "github.com/aos-dev/go-service-fs"
+	qingstor "github.com/aos-dev/go-service-qingstor"
 	"github.com/aos-dev/go-storage/v2"
 	"github.com/aos-dev/go-storage/v2/pkg/endpoint"
 	typ "github.com/aos-dev/go-storage/v2/types"
@@ -448,7 +448,7 @@ func TestNewQingStorStorage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			defer monkey.UnpatchAll()
 			monkey.Patch(qingstor.NewStorager, func(pairs ...*typ.Pair) (storage.Storager, error) {
-				assert.Equal(t, 3, len(pairs), tt.name)
+				assert.Equal(t, 4, len(pairs), tt.name)
 				return &qingstor.Storage{}, nil
 			})
 

--- a/utils/task_test.go
+++ b/utils/task_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"bou.ke/monkey"
+	"github.com/agiledragon/gomonkey/v2"
 	fs "github.com/aos-dev/go-service-fs"
 	qingstor "github.com/aos-dev/go-service-qingstor"
 	"github.com/aos-dev/go-storage/v2"
@@ -117,15 +117,16 @@ func TestParseStorageInputQingstor(t *testing.T) {
 
 	for _, v := range cases {
 		t.Run(v.name, func(t *testing.T) {
-			defer monkey.UnpatchAll()
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
 			if v.pathErr != nil {
-				monkey.Patch(ParseQsPath, func(p string) (_ typ.ObjectType, _, _ string, err error) {
+				patches.ApplyFunc(ParseQsPath, func(p string) (_ typ.ObjectType, _, _ string, err error) {
 					err = v.pathErr
 					return
 				})
 			}
 
-			monkey.Patch(NewQingStorStorage, func(...*typ.Pair) (stor storage.Storager, err error) {
+			patches.ApplyFunc(NewQingStorStorage, func(...*typ.Pair) (stor storage.Storager, err error) {
 				if v.srvErr != nil {
 					err = v.srvErr
 				} else {
@@ -173,9 +174,10 @@ func TestParseServiceInput(t *testing.T) {
 
 	for _, v := range cases {
 		t.Run(v.name, func(t *testing.T) {
-			defer monkey.UnpatchAll()
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
 			if v.err == errTmp {
-				monkey.Patch(NewQingStorService, func() (_ storage.Servicer, err error) {
+				patches.ApplyFunc(NewQingStorService, func() (_ storage.Servicer, err error) {
 					err = errTmp
 					return
 				})
@@ -207,8 +209,9 @@ func TestParseAtServiceInput(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defer monkey.UnpatchAll()
-			monkey.Patch(ParseServiceInput, func(serviceType StoragerType) (service storage.Servicer, err error) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+			patches.ApplyFunc(ParseServiceInput, func(serviceType StoragerType) (service storage.Servicer, err error) {
 				assert.Equal(t, qingstor.Type, serviceType, tt.name)
 				if tt.wantErr {
 					err = errTmp
@@ -251,8 +254,9 @@ func TestParseAtStorageInput(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			defer monkey.UnpatchAll()
-			monkey.Patch(ParseStorageInput, func(input string, storageType StoragerType) (
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+			patches.ApplyFunc(ParseStorageInput, func(input string, storageType StoragerType) (
 				workDir, path string, objectType typ.ObjectType, store storage.Storager, err error) {
 				assert.Equal(t, qingstor.Type, storageType, tt.name)
 				assert.Equal(t, tt.input, input, tt.name)
@@ -265,7 +269,7 @@ func TestParseAtStorageInput(t *testing.T) {
 			})
 
 			if tt.err == ErrInvalidFlow {
-				monkey.Patch(ParseFlow, func(_, _ string) constants.FlowType {
+				patches.ApplyFunc(ParseFlow, func(_, _ string) constants.FlowType {
 					return constants.FlowInvalid
 				})
 			}
@@ -446,8 +450,9 @@ func TestNewQingStorStorage(t *testing.T) {
 
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			defer monkey.UnpatchAll()
-			monkey.Patch(qingstor.NewStorager, func(pairs ...*typ.Pair) (storage.Storager, error) {
+			patches := gomonkey.NewPatches()
+			defer patches.Reset()
+			patches.ApplyFunc(qingstor.NewStorager, func(pairs ...*typ.Pair) (storage.Storager, error) {
 				assert.Equal(t, 4, len(pairs), tt.name)
 				return &qingstor.Storage{}, nil
 			})

--- a/utils/work_dir.go
+++ b/utils/work_dir.go
@@ -4,6 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/qingstor/qsctl/v2/constants"
+	"github.com/spf13/viper"
 )
 
 // ParseFsWorkDir get a path as input, split the work dir and file by following rules
@@ -35,16 +38,20 @@ func ParseFsWorkDir(path string) (wd, file string, err error) {
 // What's difference is ParseQsWorkDir use '/' as separator, which is defined by qingstor service.
 func ParseQsWorkDir(path string) (wd, file string) {
 	// always treat qs path as abs path, so add "/" before
-	separator := "/"
-	path = separator + path
-	parts := strings.SplitAfter(path, separator)
-	// because path always start with "/", so parts' len will always longer than 2
-	// trim redundant "/" in the middle of path (not the first one)
-	for i := 1; i < len(parts); i++ {
-		if parts[i] == separator {
-			parts[i] = ""
+	const qsSeparator = "/"
+	path = qsSeparator + path
+	parts := strings.SplitAfter(path, qsSeparator)
+
+	if !viper.GetBool(constants.ConfigDisableURICleaning) {
+		// because path always start with "/", so parts' len will always longer than 2
+		// trim redundant "/" in the middle of path (not the first one)
+		for i := 1; i < len(parts); i++ {
+			if parts[i] == qsSeparator {
+				parts[i] = ""
+			}
 		}
 	}
+
 	wd = strings.Join(parts[0:len(parts)-1], "")
 	file = parts[len(parts)-1]
 	return

--- a/utils/work_dir_unix_test.go
+++ b/utils/work_dir_unix_test.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"bou.ke/monkey"
+	"github.com/agiledragon/gomonkey/v2"
 )
 
 func ExampleParseFsWorkDir() {
@@ -119,8 +119,9 @@ func TestParseWd(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			patches := gomonkey.NewPatches()
 			if tt.wantErr {
-				monkey.Patch(filepath.Abs, func(string) (string, error) {
+				patches.ApplyFunc(filepath.Abs, func(string) (string, error) {
 					return "", filepath.ErrBadPattern
 				})
 			}
@@ -135,7 +136,7 @@ func TestParseWd(t *testing.T) {
 			if gotFile != tt.wantFile {
 				t.Errorf("ParseWorkDir() gotFile = %v, want %v", gotFile, tt.wantFile)
 			}
-			monkey.Unpatch(filepath.Abs)
+			patches.Reset()
 		})
 	}
 }


### PR DESCRIPTION
awscli ensure the slashes in user input is retained, we should allow this mode by introducing a new config option: disable_uri_cleaning

So command like:
qsctl cp go.mod qs://maxtest///abc/
will act as expected.